### PR TITLE
Adding vk.com support

### DIFF
--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -26,6 +26,7 @@ export const KNOWN_LINKS = {
   VIMEO: "vimeo",
   MASTODON: "mastodon",
   OWN: "own",
+  VK: "vk",
   MISC: "general",
 };
 
@@ -92,6 +93,12 @@ export const KNOWN_LINK_PATTERNS = [
   {
     key: KNOWN_LINKS.MASTODON,
     patterns: ["^(?:https?:/{2})?(www.)?.+..+/@.*/d*"],
+  },
+  {
+    key: KNOWN_LINKS.VK,
+    patterns: [
+      "(https?:\\/{2})?(www.)?vk.com\\/(wall|video)(-?)\\d*_\\d*(\\??)",
+    ],
   },
   {
     key: KNOWN_LINKS.MISC,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
@@ -58,7 +58,8 @@ const AssistantVideoResult = () => {
         }
         break;
       case KNOWN_LINKS.YOUTUBESHORTS:
-        embedURL = null; // Null as youtube shorts does not support embedding
+      case KNOWN_LINKS.VK:
+        embedURL = null; // Null as youtube shorts and vk do not support embedding
         break;
       case KNOWN_LINKS.VIMEO:
         stringToMatch = "vimeo.com/";

--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -537,6 +537,7 @@ const decideWhetherToScrape = (urlType, contentType) => {
     case KNOWN_LINKS.TWITTER:
     case KNOWN_LINKS.TELEGRAM:
     case KNOWN_LINKS.MASTODON:
+    case KNOWN_LINKS.VK:
       return true;
     case KNOWN_LINKS.MISC:
       if (contentType === null) {
@@ -637,6 +638,7 @@ const filterAssistantResults = (
       }
       break;
     case KNOWN_LINKS.TELEGRAM:
+    case KNOWN_LINKS.VK:
       if (scrapeResult.images.length > 0) {
         imageList = scrapeResult.images;
       }
@@ -687,11 +689,9 @@ const filterSourceCredibilityResults = (
   linkList,
   trafficLightColors,
 ) => {
-  //if (!originalResult.entities.SourceCredibility) {
-  if (!originalResult) {
+  if (!originalResult.length) {
     return [null, null, null, null];
   }
-  //let sourceCredibility = originalResult.entities.SourceCredibility;
   let sourceCredibility = originalResult;
 
   sourceCredibility.forEach((dc) => {


### PR DESCRIPTION
Added support for scraping vk.com to frontend
- edited KNOWN_LINKS to accept links of these formats
	- [https://vk.com/wall-57424472_432130](https://vk.com/wall-57424472_432130)
	- [https://vk.com/video-57424472_456319931](https://vk.com/video-57424472_456319931)
	- [https://vk.com/wall634116626_1884](https://vk.com/wall634116626_1884?)
	- [https://vk.com/wall623312115_141404](https://vk.com/wall623312115_141404)
- directing videos as prohibited to embed like youtube videos

Not related errors fixed 
- error with positive source credibility not existing, corrected how to check existence in AssistantSaga.jsx line 692 
	- originalResult -> originalResult.length
	- removed comments