### PR TITLE
Remove important sentence highlighting if no topics detected

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -115,6 +115,10 @@ export default function AssistantTextClassification({
     }
   }
 
+  if (Object.keys(filteredCategories).length == 0) {
+    filteredSentences = [];
+  }
+
   // disabled category box for Subjectivity classifier
   // subjectivty or not
   // let width = 12;


### PR DESCRIPTION
Closes https://github.com/GateNLP/we-verify-app-assistant/issues/202
Previously, we had
![image](https://github.com/user-attachments/assets/dc840565-506d-49f6-bc88-b2d97d472b34)
Now we have
![image](https://github.com/user-attachments/assets/169b11bb-e0e2-467f-8b07-460489c43ae2)
