### PR TITLE
assistant/fixed empty subjectivity sentences

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -168,7 +168,7 @@ export default function AssistantTextClassification({
   if (Object.keys(filteredCategories).length === 0) {
     filteredSentences = [];
   }
-  if (credibilitySignal === keyword("subjectivity_title") && Object.keys(filteredSentences).length == 0) {
+  if (credibilitySignal === keyword("subjectivity_title") && Object.keys(filteredSentences).length === 0) {
     filteredCategories = [];
   }
 


### PR DESCRIPTION
Sometimes subjectivity `filteredSentences` is empty because the sentence scores are below the threshold, but the category 'Subjective' is still being displayed
- check if `filteredSentences` is empty and if so make `filteredCategories` empty too