### PR TITLE
Assistant/950 fix misaligned tooltip close

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/assistantUtils.jsx
@@ -167,26 +167,38 @@ export const renderUrlTitle = (
       {handleClose != null ? (
         <Grid size={{ xs: 1 }} display="flex" justifyContent="flex-end">
           {/* tooltip help */}
-          <Tooltip
-            interactive={"true"}
-            leaveDelay={50}
-            style={{ display: "flex", marginLeft: "auto" }}
-            title={
-              <>
-                <TransSourceCredibilityTooltip keyword={keyword} />
-                <TransHtmlDoubleLineBreak keyword={keyword} />
-                <TransUrlDomainAnalysisLink keyword={keyword} />
-              </>
-            }
-            classes={{ tooltip: classes.assistantTooltip }}
+          <Box
+            sx={{
+              pt: 0.75,
+            }}
           >
-            <HelpOutlineOutlinedIcon color={"action"} />
-          </Tooltip>
+            <Tooltip
+              interactive={"true"}
+              leaveDelay={50}
+              style={{ display: "flex", marginLeft: "auto" }}
+              title={
+                <>
+                  <TransSourceCredibilityTooltip keyword={keyword} />
+                  <TransHtmlDoubleLineBreak keyword={keyword} />
+                  <TransUrlDomainAnalysisLink keyword={keyword} />
+                </>
+              }
+              classes={{ tooltip: classes.assistantTooltip }}
+            >
+              <HelpOutlineOutlinedIcon color={"action"} />
+            </Tooltip>
+          </Box>
 
           {/* close button */}
-          <IconButton onClick={handleClose}>
-            <CloseIcon />
-          </IconButton>
+          <Box
+            sx={{
+              pr: 1,
+            }}
+          >
+            <IconButton onClick={handleClose}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
         </Grid>
       ) : null}
     </Grid>


### PR DESCRIPTION
Closes #950 

Separate `Box`s around tooltip and close button in details of Extracted URLs with URL Domain Analysis was accidentally removed in https://github.com/AFP-Medialab/verification-plugin/pull/859/files#, putting them back in to fix the misalignment and incorrect highlight.

Fixed:
<img width="309" height="130" alt="499053838-f227ef09-3ed3-44e0-b256-adb9a7e4e7c1" src="https://github.com/user-attachments/assets/3f84c271-a718-4bdc-a6aa-586263a60ad3" />
