### PR TITLE
assistant/951 change keyword checks

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -39,7 +39,6 @@ export default function AssistantTextClassification({
   text,
   classification,
   overallClassification,
-  titleText = "",
   categoriesTooltipContent = "",
   configs = {
     // machine generated text and subjectivity
@@ -71,10 +70,10 @@ export default function AssistantTextClassification({
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");
 
   // titles
-  const newsFramingTitle = keyword("news_framing_title");
-  const newsGenreTitle = keyword("news_genre_title");
-  const subjectivityTitle = keyword("subjectivity_title");
-  const machineGeneratedTextTitle = keyword("machine_generated_text_title");
+  const newsFramingTitle = "news_framing_title";
+  const newsGenreTitle = "news_genre_title";
+  const subjectivityTitle = "subjectivity_title";
+  const machineGeneratedTextTitle = "machine_generated_text_title";
 
   // slider
   const importantSentenceThreshold = useSelector(
@@ -210,6 +209,7 @@ export default function AssistantTextClassification({
           credibilitySignal={credibilitySignal}
           keyword={keyword}
           resolvedMode={resolvedMode}
+          machineGeneratedTextTitle={machineGeneratedTextTitle}
         />
       </Grid>
 
@@ -218,7 +218,7 @@ export default function AssistantTextClassification({
         <Card>
           <CardHeader
             className={classes.assistantCardHeader}
-            title={titleText}
+            title={keyword(credibilitySignal)}
             action={
               <div style={{ display: "flex" }}>
                 <Tooltip
@@ -246,6 +246,8 @@ export default function AssistantTextClassification({
                 gaugeLabels={["gauge_no_detection", "gauge_detection"]}
                 orderedCategories={orderedCategories}
                 credibilitySignal={credibilitySignal}
+                machineGeneratedTextTitle={machineGeneratedTextTitle}
+                subjectivityTitle={subjectivityTitle}
               />
             ) : credibilitySignal === subjectivityTitle ? (
               <GaugeCategoriesList
@@ -264,6 +266,8 @@ export default function AssistantTextClassification({
                 credibilitySignal={credibilitySignal}
                 importantSentenceThreshold={importantSentenceThreshold}
                 handleSliderChange={handleSliderChange}
+                machineGeneratedTextTitle={machineGeneratedTextTitle}
+                subjectivityTitle={subjectivityTitle}
               />
             ) : (
               <CategoriesList
@@ -273,6 +277,8 @@ export default function AssistantTextClassification({
                 credibilitySignal={credibilitySignal}
                 importantSentenceThreshold={importantSentenceThreshold}
                 handleSliderChange={handleSliderChange}
+                newsFramingTitle={newsFramingTitle}
+                newsGenreTitle={newsGenreTitle}
               />
             )}
           </CardContent>
@@ -296,6 +302,8 @@ export function GaugeCategoriesList({
   credibilitySignal,
   importantSentenceThreshold,
   handleSliderChange,
+  machineGeneratedTextTitle,
+  subjectivityTitle,
 }) {
   // gauge chart
   const gaugeChart = createGaugeChart(
@@ -310,7 +318,7 @@ export function GaugeCategoriesList({
 
   // categories list
   const output = [];
-  if (credibilitySignal === keyword("machine_generated_text_title")) {
+  if (credibilitySignal === machineGeneratedTextTitle) {
     for (const category of orderedCategories) {
       if (category != fullTextScoreLabel && category in categories) {
         output.push(
@@ -347,7 +355,7 @@ export function GaugeCategoriesList({
 
   return (
     <>
-      {credibilitySignal === keyword("subjectivity_title") ? (
+      {credibilitySignal === subjectivityTitle ? (
         <>
           {_.isEmpty(categories) && overallScore === 0 ? (
             <>
@@ -376,7 +384,7 @@ export function GaugeCategoriesList({
         <GaugeChartModalExplanation
           keyword={keyword}
           keywordsArr={
-            credibilitySignal === keyword("machine_generated_text_title")
+            credibilitySignal === machineGeneratedTextTitle
               ? DETECTION_EXPLANATION_KEYWORDS_MGT
               : DETECTION_EXPLANATION_KEYWORDS_SUB
           }
@@ -385,7 +393,7 @@ export function GaugeCategoriesList({
           colors={colours}
         />
       </Box>
-      {credibilitySignal === keyword("machine_generated_text_title") && (
+      {credibilitySignal === machineGeneratedTextTitle && (
         <>
           <Divider key={`divider_${fullTextScoreLabel}`} sx={{ my: 2 }} />
           <Typography fontSize="small" sx={{ textAlign: "start" }}>
@@ -406,16 +414,18 @@ export function CategoriesList({
   credibilitySignal,
   importantSentenceThreshold,
   handleSliderChange,
+  newsFramingTitle,
+  newsGenreTitle,
 }) {
   if (_.isEmpty(categories)) {
     return (
       <>
-        {credibilitySignal === keyword("news_framing_title") && (
+        {credibilitySignal === newsFramingTitle && (
           <Typography fontSize="small" sx={{ textAlign: "center" }}>
             {keyword("no_detected_topics")}
           </Typography>
         )}
-        {credibilitySignal === keyword("news_genre_title") && (
+        {credibilitySignal === newsGenreTitle && (
           <Typography fontSize="small" sx={{ textAlign: "center" }}>
             {keyword("no_detected_genre")}
           </Typography>
@@ -470,15 +480,15 @@ export function ClassifiedText({
   primaryRgb,
   textHtmlMap = null,
   credibilitySignal,
-  keyword,
   resolvedMode,
+  machineGeneratedTextTitle,
 }) {
   let output = text; // Defaults to text output
 
   function wrapHighlightedText(spanText, spanInfo) {
     let bgLuminance;
     let textColour = "black";
-    if (credibilitySignal === keyword("machine_generated_text_title")) {
+    if (credibilitySignal === machineGeneratedTextTitle) {
       backgroundRgb = resolvedMode === "dark" ? spanInfo.rgbDark : spanInfo.rgb;
       bgLuminance = rgbToLuminance(backgroundRgb);
       if (spanInfo.pred == "highly_likely_machine") textColour = "white";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -63,7 +63,7 @@ const AssistantTextResult = () => {
   );
 
   // news framing (topic)
-  const newsFramingTitle = keyword("news_framing_title");
+  const newsFramingTitle = "news_framing_title";
   const newsFramingResult = useSelector(
     (state) => state.assistant.newsFramingResult,
   );
@@ -75,7 +75,7 @@ const AssistantTextResult = () => {
   );
 
   // news genre
-  const newsGenreTitle = keyword("news_genre_title");
+  const newsGenreTitle = "news_genre_title";
   const newsGenreResult = useSelector(
     (state) => state.assistant.newsGenreResult,
   );
@@ -85,7 +85,7 @@ const AssistantTextResult = () => {
   const newsGenreFail = useSelector((state) => state.assistant.newsGenreFail);
 
   // persuasion techniques
-  const persuasionTitle = keyword("persuasion_techniques_title");
+  const persuasionTitle = "persuasion_techniques_title";
   const persuasionResult = useSelector(
     (state) => state.assistant.persuasionResult,
   );
@@ -95,7 +95,7 @@ const AssistantTextResult = () => {
   const persuasionFail = useSelector((state) => state.assistant.persuasionFail);
 
   // subjectivity
-  const subjectivityTitle = keyword("subjectivity_title");
+  const subjectivityTitle = "subjectivity_title";
   const subjectivityResult = useSelector(
     (state) => state.assistant.subjectivityResult,
   );
@@ -107,7 +107,7 @@ const AssistantTextResult = () => {
   );
 
   // machine generated text
-  const machineGeneratedTextTitle = keyword("machine_generated_text_title");
+  const machineGeneratedTextTitle = "machine_generated_text_title";
   const machineGeneratedTextChunksResult = useSelector(
     (state) => state.assistant.machineGeneratedTextChunksResult,
   );
@@ -290,7 +290,7 @@ const AssistantTextResult = () => {
           <Tab
             label={
               <div>
-                {newsFramingTitle}
+                {keyword(newsFramingTitle)}
                 {newsFramingLoading && <LinearProgress />}
               </div>
             }
@@ -300,7 +300,7 @@ const AssistantTextResult = () => {
           <Tab
             label={
               <div>
-                {newsGenreTitle}
+                {keyword(newsGenreTitle)}
                 {newsGenreLoading && <LinearProgress />}
               </div>
             }
@@ -310,7 +310,7 @@ const AssistantTextResult = () => {
           <Tab
             label={
               <div>
-                {persuasionTitle}
+                {keyword(persuasionTitle)}
                 {persuasionLoading && <LinearProgress />}
               </div>
             }
@@ -320,7 +320,7 @@ const AssistantTextResult = () => {
           <Tab
             label={
               <div>
-                {subjectivityTitle}
+                {keyword(subjectivityTitle)}
                 {subjectivityLoading && <LinearProgress />}
               </div>
             }
@@ -330,7 +330,7 @@ const AssistantTextResult = () => {
           <Tab
             label={
               <div>
-                {machineGeneratedTextTitle}
+                {keyword(machineGeneratedTextTitle)}
                 {(machineGeneratedTextChunksLoading ||
                   machineGeneratedTextSentencesLoading) && <LinearProgress />}
               </div>
@@ -368,7 +368,6 @@ const AssistantTextResult = () => {
               text={text}
               classification={newsFramingResult?.entities}
               configs={newsFramingResult?.configs}
-              titleText={newsFramingTitle}
               categoriesTooltipContent={newsFramingTooltip}
               textHtmlMap={textHtmlMap}
               credibilitySignal={newsFramingTitle}
@@ -381,7 +380,6 @@ const AssistantTextResult = () => {
               text={text}
               classification={newsGenreResult?.entities}
               configs={newsGenreResult?.configs}
-              titleText={newsGenreTitle}
               categoriesTooltipContent={newsGenreTooltip}
               textHtmlMap={textHtmlMap}
               credibilitySignal={newsGenreTitle}
@@ -394,9 +392,9 @@ const AssistantTextResult = () => {
               text={text}
               classification={persuasionResult?.entities}
               configs={persuasionResult?.configs}
-              titleText={persuasionTitle}
               categoriesTooltipContent={persuasionTooltip}
               textHtmlMap={textHtmlMap}
+              credibilitySignal={persuasionTitle}
             />
           </CustomTabPanel>
 
@@ -406,7 +404,6 @@ const AssistantTextResult = () => {
               text={text}
               classification={subjectivityResult?.entities}
               configs={subjectivityResult?.configs}
-              titleText={subjectivityTitle}
               categoriesTooltipContent={subjectivityTooltip}
               textHtmlMap={textHtmlMap}
               credibilitySignal={subjectivityTitle}
@@ -420,7 +417,6 @@ const AssistantTextResult = () => {
               classification={machineGeneratedTextSentencesResult?.entities}
               overallClassification={machineGeneratedTextChunksResult?.entities}
               configs={machineGeneratedTextSentencesResult?.configs}
-              titleText={machineGeneratedTextTitle}
               categoriesTooltipContent={machineGeneratedTextTooltip}
               textHtmlMap={textHtmlMap}
               credibilitySignal={machineGeneratedTextTitle}

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -46,9 +46,9 @@ const StyledSpan = styled("span")(({ theme }) => ({
 export default function AssistantTextSpanClassification({
   text,
   classification,
-  titleText = "",
   categoriesTooltipContent = "",
   textHtmlMap = null,
+  credibilitySignal = "",
 }) {
   const classes = useMyStyles();
   const dispatch = useDispatch();
@@ -281,7 +281,7 @@ export default function AssistantTextSpanClassification({
         <Card>
           <CardHeader
             className={classes.assistantCardHeader}
-            title={titleText}
+            title={keyword(credibilitySignal)}
             action={
               <div style={{ display: "flex" }}>
                 <Tooltip


### PR DESCRIPTION
Closes #951

Removed `keyword` checks and the duplicate `titleText` variable as `credibilitySignal` is essentially the same.
- checked titles are wrapped in `keyword` in the right place