### PR TITLE
Assistant/ fix error with unset datagrid size

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -350,12 +350,11 @@ const AssistantLinkResult = () => {
       <CardContent
         style={{
           wordBreak: "break-word",
-          overflowY: "auto",
-          overflowX: "hidden",
+          overflow: "hidden",
+          height: 450,
         }}
       >
-        {/* issue with resize related to parent not having a fixed/determined size? */}
-        <div style={{ height: 400, width: "100%", minWidth: 0 }}>
+        <Box sx={{ height: "100%", width: "100%" }}>
           <DataGrid
             rows={rows}
             columns={columns}
@@ -367,7 +366,7 @@ const AssistantLinkResult = () => {
               },
             }}
           />
-        </div>
+        </Box>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Page remains the same but error in console for the DataGrid containing the list of Extract URLs with URL Domain Analysis
- This PR makes sure parent dimensions are explicit
- Error doesn't occur

```
index.js:65 MUI X: useResizeContainer - The parent DOM element of the Data Grid has an empty height.
Please make sure that this element has an intrinsic height.
The grid displays with a height of 0px.

More details: https://mui.com/r/x-data-grid-no-dimensions.

index.js:65 Warning: Can't perform a React state update on a component that hasn't mounted yet. This indicates that you have a side-effect in your render function that asynchronously later calls tries to update the component. Move this work to useEffect instead.
    at GridVirtualScrollbar (chrome-extension://kpbecamjjhhfhbaopkmjpolhgnldohgb/popup.js:87204:116)
    at div
    at chrome-extension://kpbecamjjhhfhbaopkmjpolhgnldohgb/popup.js:2435:66
    at chrome-extension://kpbecamjjhhfhbaopkmjpolhgnldohgb/popup.js:87053:5
    at GridVirtualScroller (chrome-extension://kpbecamjjhhfhbaopkmjpolhgnldohgb/popup.js:87391:102)
    at div
...
```