### PR TITLE
Assistant/add twitter to Keyframes tool

### DIFF
--- a/src/constants/tools.jsx
+++ b/src/constants/tools.jsx
@@ -334,6 +334,7 @@ export const keyframes = new Tool(
   <Footer type={FOOTER_TYPES.ITI} />,
   {
     linksAccepted: [
+      KNOWN_LINKS.TWITTER,
       KNOWN_LINKS.YOUTUBE,
       KNOWN_LINKS.FACEBOOK,
       KNOWN_LINKS.YOUTUBE,


### PR DESCRIPTION
For keyframes tool, `linksAccepted` needed `KNOWN_LINKS.TWITTER` added to show up for videos on x
- https://x.com/SilviusBerthold/status/1970925238432002309
- Keyframes with this x link works, so adding x/twitter back into accepted links for the tool through the assistant

