### PR TITLE
fix CSS hover rules in AssistantTextSpanClassification

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -201,7 +201,7 @@ export default function AssistantTextSpanClassification({
                 ? "black"
                 : "white"
               : "black",
-            ":hover": {
+            "&:hover": {
               background: rgbToString(backgroundRgbHover),
               color: resolvedMode === "dark" ? "black" : "white",
             },
@@ -391,7 +391,7 @@ export function CategoriesListToggle({
               : rgbToString([140, 140, 140]),
           color: rgbToLuminance(primaryRgb) > 0.7 ? "black" : "white",
           boxShadow: "0.15em 0.15em 0.15em gray",
-          ":hover": {
+          "&:hover": {
             background: rgbToString(primaryRgb),
             boxShadow: "0.25em 0.25em 0.25em gray",
           },


### PR DESCRIPTION
Hover rules in a couple of `sx` properties were mistakenly entered as `:hover`, meaning that once the relevant CSS fragment was added to the DOM, _every_ element in the whole document gained the green-background hover behaviour, not just the element corresponding to this component.

Fixed by changing them to `&:hover` to target this component specifically.