### PR TITLE
Assistant/remove frontendVersion variable

### DIFF
--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
@@ -205,7 +205,6 @@ export default function assistantApiCalls() {
           assistantEndpoint + "gcloud/source-credibility",
           {
             urls: urlList,
-            frontendVersion: "0.88",
           },
         );
         return result.data;


### PR DESCRIPTION
As v0.88 has been released, can remove backwards compatibility code
- remove `frontendVersion` variable for persuasion techniques,subjectivity credibility signals and source credibility/URL Domain Analysis