### PR TITLE
Asssitant/Previous fact checks language error

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResults.jsx
@@ -57,7 +57,7 @@ const PreviousFactCheckResults = ({ results }) => {
                   null
                 }
                 website={resultItem.website ?? resultItem.source_name}
-                language={getLanguageName(resultItem.source_language)}
+                language={getLanguageName(resultItem.source_language, resultItem.source_language)}
                 similarityScore={resultItem.score}
                 articleUrl={resultItem.url}
                 domainUrl={resultItem.source_name}


### PR DESCRIPTION
An error in `getLanguageName` was caused by a missing parameter, added second parameter as a duplicate of the first mimicking `SemanticSearchResults.jsx`

https://github.com/AFP-Medialab/verification-plugin/blob/e7b55ee9481ee6b4b7e2fcd2f1b951ef83043f6a/src/components/NavItems/tools/SemanticSearch/SemanticSearchResults.jsx#L135-L138