### PR TITLE
Assistant/Persuasion keyword error

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -179,7 +179,7 @@ export default function AssistantTextSpanClassification({
             cursor: "pointer",
           }}
         >
-          {keyword(divText)}
+          {divText}
         </div>,
       );
     }


### PR DESCRIPTION
There was a missing keyword error with the hover text in persuasion techniques. This was caused by using `keyword` around something that is a combination of two `keyword`s already
- removed the final `keyword`