### PR TITLE
Assistant/source cred input url fix

### DIFF
--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -330,15 +330,9 @@ function* handleSourceCredibilityCall(action) {
 
     yield put(
       setInputSourceCredDetails(
-        result.url.inputUrl > 0
-          ? result.domain[result.url.inputUrl[0].resolvedDomain].positive
-          : null, // input url positive
-        result.url.inputURL > 0
-          ? result.domain[result.url.inputUrl[0].resolvedDomain].caution
-          : null, // input url caution
-        result.url.inputURL > 0
-          ? result.domain[result.url.inputUrl[0].resolvedDomain].mixed
-          : null, // input url mixed
+        result.domain[result.url.inputUrl.credibilityScope]?.positive,
+        result.domain[result.url.inputUrl.credibilityScope]?.caution,
+        result.domain[result.url.inputUrl.credibilityScope]?.mixed,
         result, // all the rest results
         trafficLightColors,
         sourceTypes,


### PR DESCRIPTION
Fixed problem with source credibility results not displaying for input URL.
- problem of missing `.length` with comparison
- removed `[0]` as backend sending `inputUrl` as single dictionary, not a list
- backend sets to `null` already if empty so ternary operator is not needed
- `resolvedDomain` swapped to `credibilityScope` so as to pick up accounts correctly (x.com/LordBebo instead of x.com)

Tested with these result situations:
- input URL SC result, no extracted URLs SC results: https://x.com/MyLordBebo/status/1892116615161917896
- input URL SC result with extracted URLs SC results: https://www.breitbart.com/europe/2025/12/01/biggest-threat-in-800-years-scrapping-juries-imperils-freedom-of-speech/
- no input URL SC result, no extracted URLs SC results: https://www.eauc.org.uk/learning/carbon-literacy-training/ 
- no input URL SC result with extracted URLs SC results: https://www.snopes.com/fact-check/elvis-danny-sullivan-story/