### PR TITLE
assistant/remove mgt check for login

### DIFF
--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -120,14 +120,14 @@ function* getPrevFactChecksSaga() {
 
 function* getMachineGeneratedTextChunksSaga() {
   yield takeLatest(
-    ["SET_SCRAPED_DATA", "AUTH_USER_LOGIN", "CLEAN_STATE"],
+    ["SET_SCRAPED_DATA", "CLEAN_STATE"],
     handleMachineGeneratedTextChunksCall,
   );
 }
 
 function* getMachineGeneratedTextSentencesSaga() {
   yield takeLatest(
-    ["SET_SCRAPED_DATA", "AUTH_USER_LOGIN", "CLEAN_STATE"],
+    ["SET_SCRAPED_DATA", "CLEAN_STATE"],
     handleMachineGeneratedTextSentencesCall,
   );
 }


### PR DESCRIPTION
Machine generated text is now open to all users of the plugin, remove check for login to prevent saga rerunning.