### PR TITLE
Assistant/remove fcss tooltip when not beta tester

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
@@ -110,6 +110,16 @@ const AssistantWarnings = () => {
           index === self.findIndex((item) => item.id === obj.id),
       );
     }
+  } else {
+    // not logged in and dbkf only
+    dbkfTextMatch
+      ? dbkfTextMatch.forEach((dbkfResult) => {
+          separateDbkfTextMatch.push({
+            ...dbkfResult,
+            factCheckServices: [DBKF],
+          });
+        })
+      : null;
   }
 
   return (
@@ -155,7 +165,7 @@ const AssistantWarnings = () => {
         {/* not logged in as beta tester, DBKF only */}
         {!role.includes(ROLES.BETA_TESTER) && dbkfTextMatch && (
           <DbkfTextResults
-            results={dbkfTextMatch}
+            results={separateDbkfTextMatch}
             prevFactChecksExist={false}
           />
         )}


### PR DESCRIPTION
Noticed FCSS tooltip appears when user not logged in so changed this to appear only when beta-tester. Also added in DBKF chip for non beta-tester users for consistency.
- https://www.arabnews.jp/en/japan/article_152719/
- not logged in
<img width="1183" height="260" alt="Screenshot 2025-12-22 132120" src="https://github.com/user-attachments/assets/0a25c87a-0440-49b4-9351-4164caaf4582" />



- beta-tester logged in
<img width="1179" height="676" alt="Screenshot 2025-12-22 130659" src="https://github.com/user-attachments/assets/828239e2-1290-47f5-9fc8-a1aa25c82472" />
