### PR TITLE
Assistant/Added optional chaining to catch when dbkfTextMatch is null

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
@@ -19,7 +19,7 @@ const DbkfTextResults = ({ results, prevFactChecksExist }) => {
   return (
     <>
       {/* This code mimics ResultDisplayItem.jsx from SemanticSearch to match output */}
-      {results.map((value, key) => {
+      {results?.map((value, key) => {
         return (
           <Box
             key={key}


### PR DESCRIPTION
Added optional chaining to catch when dbkfTextMatch is null
- this link now works as expected https://x.com/AdameMedia/status/2016176079061282905

<img width="1096" height="687" alt="image" src="https://github.com/user-attachments/assets/6f0d8ad5-e7ad-4ef3-a6b1-5b3b5d0679b3" />
