### PR TITLE
Assistant/Add guard to matchPattern

### DIFF
--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -241,6 +241,9 @@ export const selectCorrectActions = (
 };
 
 export const matchPattern = (toMatch, matchObject) => {
+  if (!toMatch) {
+    return null;
+  }
   // find the record where from the regex patterns in said record, one of them matches "toMatch"
   let match = matchObject.find((record) =>
     record.patterns.some((rgxpattern) => toMatch.match(rgxpattern) != null),


### PR DESCRIPTION
Occasional (but not always) error in AssistantRuleBook when toMatch would be null.
- Added guard to catch and prevent error from happening