### PR TITLE
Assistant/fix space in url

### DIFF
--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -290,7 +290,7 @@ const Assistant = () => {
   useEffect(() => {
     if (url !== undefined && !hasSubmitted) {
       // only handle user-entered spaces which shouldn't normally be in URLs
-      const uri = url.replace(/ /g, "%20");
+      const uri = url !== null ? url.replace(/ /g, "%20") : undefined;
       dispatch(setUrlMode(true));
       setFormInput(uri);
       dispatch(submitInputUrl(uri));


### PR DESCRIPTION
Example URL: https://www.afp.com/sites/default/files/2025-12/Proposition%207.png
- it has "%20" in it which was being replaced by a space when submitted. This was sent to backend for wrong results and displayed to user incorrectly
- replaced space with "%20"
- the url change causes `handleSubmit` to be called twice so added `hasSubmitted` check
- remove decode as `useParams()` already decodes
