### PR TITLE
Assistant/Firefox needs explicit addon ID

### DIFF
--- a/wxt.config.js
+++ b/wxt.config.js
@@ -56,6 +56,16 @@ export default defineConfig({
         matches: ["<all_urls>"],
       },
     }),
+
+    // Firefox requires explicit addon ID for storage API to work
+    ...(browser === "firefox" && {
+      browser_specific_settings: {
+        gecko: {
+          id: "weverify@localhost.dev",
+          strict_min_version: "109.0",
+        },
+      },
+    }),
   }),
 
   srcDir: "src",


### PR DESCRIPTION
Plugin works on Firefox but Assistant backend unable to run with this error

```
Error loading from storage: Error: The storage API will not work with a temporary addon ID. Please add an explicit addon ID to your manifest. For more information see https://mzl.la/3lPk1aE.
```

Added explicit addon ID for storage API with firefox
- this is a change in `wxt.config.js` with a unique email like ID