### PR TITLE
Assistant/Fix subheader text colour

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -170,9 +170,6 @@ const AssistantMediaResult = ({ title = null }) => {
             </div>
           </div>
         }
-        slotProps={{
-          subheader: { sx: { color: "white" } },
-        }}
       />
       {dbkfMediaMatchLoading ? (
         <div>

--- a/src/components/Shared/MaterialUiStyles/useMyStyles.jsx
+++ b/src/components/Shared/MaterialUiStyles/useMyStyles.jsx
@@ -320,6 +320,9 @@ const styles = (theme) => ({
   assistantCardHeader: {
     fontSize: theme.typography.h6.fontSize,
     textAlign: "start",
+    "& .MuiCardHeader-subheader": {
+      color: "var(--mui-palette-text-primary)",
+    },
   },
   assistantHover: {
     borderWidth: 3,


### PR DESCRIPTION
Closes #1056 

"Select the media you would like to verify" text was invisible in light mode but visible in dark mode
- specify MUI css colour for subheader in assistantCardHEader style
- Remove conflicting slotprops