### PR TITLE
Assistant/center url domain analysis chip

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantUrlDomainAnalysisResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantUrlDomainAnalysisResults.jsx
@@ -140,7 +140,7 @@ const AssistantSCResults = () => {
             in={assuranceExpanded}
             className={classes.assistantBackground}
           >
-            <Box mt={3} ml={2}>
+            <Box mt={3} ml={2} textAlign="center">
               {/* Caution/Warning */}
               {positiveSourceCred?.length > 0 ? (
                 <>


### PR DESCRIPTION
The chip for the source type in URL Domain Analysis had lost it's centering, added `textAlign="center"`