### PR TITLE
Assistant/set url form

### DIFF
--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -291,6 +291,14 @@ const Assistant = () => {
     }
   }, [url]);
 
+  // when navigating to a different tool then back to assistant
+  // make sure url is set in form
+  useEffect(() => {
+    if (inputUrl) {
+      setFormInput(inputUrl);
+    }
+  }, [inputUrl]);
+
   // for having a single results section with a close button
   const handleClose = () => {
     cleanAssistant();


### PR DESCRIPTION
Closes #1072 

When navigating to a tool then back to assistant, the url is set to the form again.