### PR TITLE
Assistant/centre named entity labels

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -3,6 +3,7 @@ import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 import { TagCloud } from "react-tagcloud";
 
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Card from "@mui/material/Card";
@@ -152,28 +153,30 @@ const AssistantNEResult = () => {
         />
         {neLoading && <LinearProgress />}
         <CardContent>
-          <ButtonGroup sx={{ paddingBottom: "15px" }}>
-            {neResult.map((tag) => (
-              <Button
-                className={
-                  visibleCategories[tag.category.toLowerCase()]
-                    ? classes.namedEntityButtonHidden
-                    : ""
-                }
-                style={{
-                  color: "white",
-                  border: "none",
-                  backgroundColor: getWordColor(tag),
-                }}
-                key={tag.category}
-                onClick={() => toggleCategory(tag.category.toLowerCase())}
-              >
-                {tag.category}
-              </Button>
-            ))}
-          </ButtonGroup>
+          <Box sx={{ textAlign: "center" }}>
+            <ButtonGroup sx={{ paddingBottom: 2 }}>
+              {neResult.map((tag) => (
+                <Button
+                  className={
+                    visibleCategories[tag.category.toLowerCase()]
+                      ? classes.namedEntityButtonHidden
+                      : ""
+                  }
+                  style={{
+                    color: "white",
+                    border: "none",
+                    backgroundColor: getWordColor(tag),
+                  }}
+                  key={tag.category}
+                  onClick={() => toggleCategory(tag.category.toLowerCase())}
+                >
+                  {tag.category}
+                </Button>
+              ))}
+            </ButtonGroup>
+          </Box>
           <Grid container>
-            <Grid align={"center"}>
+            <Grid sx={{ textAlign: "center" }}>
               <TagCloud
                 tags={neResultCount}
                 shuffle={false}


### PR DESCRIPTION
This seemed to have been missed so doing another PR
- Centering of named entities was missing: the buttons and corrected the word cloud