### PR TITLE
Assistant/ner wikipedia links

### DIFF
--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
@@ -62,7 +62,7 @@ export default function assistantApiCalls() {
       const wdQuery = `
       SELECT (REPLACE(STR(?concept), "http://www.wikidata.org/entity/", "") AS ?conceptID)
       (STR(?article) AS ?wikipediaUrl)
-      (REPLACE(STR(?article), "https://${lang}.wikipedia.org/wiki/", "${dbpedia}/page/") AS ?link)
+      (REPLACE(STR(?article), "https://${lang}.wikipedia.org/wiki/", "${dbpedia}/page/") AS ?dbpediaUrl)
       (REPLACE(STR(?article), "https://${lang}.wikipedia.org/wiki/", "${dbpedia}/resource/") AS ?iri)
       ?title
       WHERE {


### PR DESCRIPTION
Feedback from Denis - change NER links from DBpedia to Wikipedia.
- decided to keep the references internally to DBpedia, with the distinction between pages and resources
- line 82: link is now set to wikipediaUrl