### PR TITLE
Assistant/matchPattern add guard again

### DIFF
--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -242,6 +242,9 @@ export const selectCorrectActions = (
 
 export const matchPattern = (toMatch, matchObject) => {
   // find the record where from the regex patterns in said record, one of them matches "toMatch"
+  if (!toMatch) {
+    return null;
+  }
   let match = matchObject.find((record) =>
     record.patterns.some((rgxpattern) => toMatch.match(rgxpattern) != null),
   );


### PR DESCRIPTION
Noticed the guard has been removed
- this was added  in this PR https://github.com/AFP-Medialab/verification-plugin/pull/1044
- but not properly added to beta-master?
- this guard to `matchPattern` prevents the assistant from crashing with this error when `toMatch` is empty. This occasionally occurs when a new link is being submitted

```
chunk-HBNXV3C2.js:9176 Uncaught TypeError: Cannot read properties of null (reading 'match')
    at localhost:3000/src/c…RuleBook.jsx:236:62
    at Array.some (<anonymous>)
    at localhost:3000/src/c…RuleBook.jsx:236:33
    at Array.find (<anonymous>)
    at matchPattern (localhost:3000/src/c…RuleBook.jsx:235:27)
    at AssistantCheckStatus (localhost:3000/src/c…eckStatus.jsx:68:19)
    at renderWithHooks (chunk-HBNXV3C2.js:11596:26)
    at mountIndeterminateComponent (chunk-HBNXV3C2.js:14974:21)
    at beginWork (chunk-HBNXV3C2.js:15962:22)
    at beginWork$1 (chunk-HBNXV3C2.js:19806:22)
```