### PR TITLE
Assistant/Extracted URLs fix ternary

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -197,11 +197,7 @@ const AssistantLinkResult = () => {
 
       // find correct source type label
       let sourceTypeList = [
-        sourceTypes
-          ? sourceTypes.unlabelled
-            ? unlabelled
-            : unlabelled
-          : unlabelled,
+        sourceTypes?.unlabelled ? keyword(sourceTypes.unlabelled) : unlabelled,
       ];
       if (domainResults.positive) {
         urlColor = trafficLightColors.positive;


### PR DESCRIPTION
Changing the ternary into a much neater and simpler check