### PR TITLE
Assistant/domain analysis align headers

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedUrlDomainAnalysisResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedUrlDomainAnalysisResults.jsx
@@ -92,6 +92,7 @@ const ExtractedUrlDomainAnalysisResults = ({
                     maxWidth={"lg"}
                     open={open}
                     scroll={"paper"}
+                    sx={{ "& .MuiDialog-paper": { minWidth: "50%" } }}
                   >
                     <DialogTitle>
                       {/* display the url */}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedUrlDomainAnalysisResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedUrlDomainAnalysisResults.jsx
@@ -128,7 +128,11 @@ const ExtractedUrlDomainAnalysisResults = ({
                                   expandIcon={<ExpandMoreIcon />}
                                 >
                                   {value.credibilityScope ? (
-                                    <Stack direction="row">
+                                    <Stack
+                                      direction="row"
+                                      spacing={1}
+                                      alignItems="center"
+                                    >
                                       {renderSourceTypeChip(
                                         keyword,
                                         trafficLightColor,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/assistantUtils.jsx
@@ -176,7 +176,7 @@ export const renderDomainTitle = (
   handleClose,
 ) => {
   return (
-    <Grid container>
+    <Grid container alignItems="center">
       {/* domain or account */}
       <Grid size={handleClose != null ? { xs: 11 } : { xs: 12 }}>
         <Typography sx={{ wordWrap: "break-word", align: "start" }}>
@@ -197,13 +197,14 @@ export const renderDomainTitle = (
       </Grid>
 
       {handleClose != null ? (
-        <Grid size={{ xs: 1 }} display="flex" justifyContent="flex-end">
+        <Grid
+          size={{ xs: 1 }}
+          display="flex"
+          justifyContent="flex-end"
+          alignItems="center"
+        >
           {/* tooltip help */}
-          <Box
-            sx={{
-              pt: 0.75,
-            }}
-          >
+          <Box>
             <Tooltip
               interactive={"true"}
               leaveDelay={50}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/assistantUtils.jsx
@@ -324,14 +324,18 @@ const renderDialog = (keyword, value, trafficLightColor, sourceType) => {
         sx={{ "& .MuiDialog-paper": { minWidth: "50%" } }}
       >
         <DialogTitle>
-          <Grid container>
+          <Grid container alignItems="center">
             <Grid size={{ xs: 11 }}>
-              <Typography variant="body1" component="div">
+              <Typography
+                variant="body1"
+                component="div"
+                sx={{ display: "flex", alignItems: "center", gap: 1 }}
+              >
                 <Chip
                   label={keyword(sourceType)}
                   color={trafficLightColor}
                   size="small"
-                />{" "}
+                />
                 {keyword("source_cred_popup_header_domain")} {value.source}
               </Typography>
             </Grid>
@@ -340,14 +344,11 @@ const renderDialog = (keyword, value, trafficLightColor, sourceType) => {
               sx={{
                 display: "flex",
                 justifyContent: "flex-end",
+                alignItems: "center",
               }}
             >
               {/* tooltip help */}
-              <Box
-                sx={{
-                  pt: 0.75,
-                }}
-              >
+              <Box>
                 <Tooltip
                   interactive={"true"}
                   leaveDelay={50}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/assistantUtils.jsx
@@ -317,7 +317,12 @@ const renderDialog = (keyword, value, trafficLightColor, sourceType) => {
       </Tooltip>
 
       {/* dialog box which appears when clicking tooltip icon above */}
-      <Dialog onClose={handleClose} maxWidth={"lg"} open={open}>
+      <Dialog
+        onClose={handleClose}
+        maxWidth={"lg"}
+        open={open}
+        sx={{ "& .MuiDialog-paper": { minWidth: "50%" } }}
+      >
         <DialogTitle>
           <Grid container>
             <Grid size={{ xs: 11 }}>


### PR DESCRIPTION
The headers for dialogs in Domain Reliability and in Extracted URLs are not aligned perfectly
- this aligns the header contents (chip, text, tooltip and close)
- also adds spacing between chip and text in Extracted URLs dialog

<img width="1029" height="221" alt="image" src="https://github.com/user-attachments/assets/4a995c3c-5d82-4b8b-a903-5d4fa71b5409" />

<img width="1228" height="428" alt="image" src="https://github.com/user-attachments/assets/b032c45f-2fe5-48e7-90d9-82b197128c87" />

- example URL: https://www.breitbart.com/europe/2026/01/28/communist-china-spied-on-uk-govt-phones-over-multiple-administrations-report/