### PR TITLE
Assistant/Fix video list display

### DIFF
--- a/src/components/Shared/VideoGridList/VideoGridList.jsx
+++ b/src/components/Shared/VideoGridList/VideoGridList.jsx
@@ -18,7 +18,11 @@ const VideoImageList = (props) => {
   const classes = useClasses(styles);
 
   return (
-    <ImageList cols={props.cols} gap={8} sx={{ width: "100%", m: 0 }}>
+    <ImageList
+      cols={props.cols}
+      style={{ rowGap: "16px", columnGap: "8px" }}
+      sx={{ width: "100%", m: 0 }}
+    >
       {props.list.map((tile, index) => (
         <ImageListItem key={index} sx={{ position: "relative" }}>
           <PlayArrowIcon

--- a/src/components/Shared/VideoGridList/VideoGridList.jsx
+++ b/src/components/Shared/VideoGridList/VideoGridList.jsx
@@ -1,19 +1,13 @@
 import React from "react";
 
-import Grid from "@mui/material/Grid";
+import ImageList from "@mui/material/ImageList";
+import ImageListItem from "@mui/material/ImageListItem";
 
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 
 import useClasses from "../MaterialUiStyles/useClasses";
 
-const styles = (theme) => ({
-  root: {
-    width: "100%",
-    display: "flex",
-    flexWrap: "wrap",
-    justifyContent: "space-around",
-    overflow: "hidden",
-  },
+const styles = () => ({
   checkeredBG: {
     background:
       "repeating-conic-gradient(#eee 0% 25%, #fafafa 0% 50%) 50% / 20px 20px",
@@ -24,48 +18,39 @@ const VideoImageList = (props) => {
   const classes = useClasses(styles);
 
   return (
-    <div className={classes.root}>
-      <Grid container spacing={1}>
-        {props.list.map((tile, index) => {
-          return (
-            <Grid
-              key={index}
-              size={{ xs: 12 / props.cols }}
-              sx={{ position: "relative" }}
-            >
-              <PlayArrowIcon
-                sx={{
-                  background: "rgba(0, 0, 0, 0.8)",
-                  display: "block",
-                  margin: "auto",
-                  width: "50px",
-                  height: "50px",
-                  borderRadius: "50%",
-                  position: "absolute",
-                  left: "50%",
-                  top: "50%",
-                  transform: "translate(-50%, -50%)",
-                  color: "white",
-                }}
-              />
-              <video
-                className={classes.checkeredBG}
-                style={{
-                  width: "auto",
-                  maxWidth: "100%",
-                  height: "120px",
-                  cursor: "pointer",
-                  margin: "0 auto",
-                }}
-                onClick={() => props.handleClick(props.list[index])}
-                data-testid={"assistant-media-grid-image-" + index}
-                src={tile}
-              ></video>
-            </Grid>
-          );
-        })}
-      </Grid>
-    </div>
+    <ImageList cols={props.cols} gap={8} sx={{ width: "100%", m: 0 }}>
+      {props.list.map((tile, index) => (
+        <ImageListItem key={index} sx={{ position: "relative" }}>
+          <PlayArrowIcon
+            sx={{
+              background: "rgba(0, 0, 0, 0.8)",
+              display: "block",
+              margin: "auto",
+              width: "50px",
+              height: "50px",
+              borderRadius: "50%",
+              position: "absolute",
+              left: "50%",
+              top: "50%",
+              transform: "translate(-50%, -50%)",
+              color: "white",
+            }}
+          />
+          <video
+            className={classes.checkeredBG}
+            style={{
+              width: "100%",
+              height: "120px",
+              cursor: "pointer",
+              display: "block",
+            }}
+            onClick={() => props.handleClick(props.list[index])}
+            data-testid={"assistant-media-grid-image-" + index}
+            src={tile}
+          ></video>
+        </ImageListItem>
+      ))}
+    </ImageList>
   );
 };
 

--- a/src/components/Shared/VideoGridList/VideoGridList.jsx
+++ b/src/components/Shared/VideoGridList/VideoGridList.jsx
@@ -11,6 +11,7 @@ const styles = (theme) => ({
     width: "100%",
     display: "flex",
     flexWrap: "wrap",
+    justifyContent: "space-around",
     overflow: "hidden",
   },
   checkeredBG: {
@@ -51,6 +52,7 @@ const VideoImageList = (props) => {
                 className={classes.checkeredBG}
                 style={{
                   width: "auto",
+                  maxWidth: "100%",
                   height: "120px",
                   cursor: "pointer",
                   margin: "0 auto",


### PR DESCRIPTION
The list of videos under Extracted media section was squished when there were multiple videos
- using ImageList component inside VideoGridList to allow videos to appear in a uniform way with 5 columns

<img width="1106" height="359" alt="image" src="https://github.com/user-attachments/assets/6df6ca21-de95-42ac-b90e-42efc38161ab" />
