### PR TITLE
Assistant/Persuasion technique empty list message correction

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -419,8 +419,6 @@ export function CategoriesListToggle({
     index++;
   }
 
-  importantSentenceThreshold == 99 ? (categoriesList = []) : null;
-
   return (
     <>
       <Typography fontSize="small" sx={{ textAlign: "start" }}>

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -312,6 +312,16 @@ export default function AssistantTextSpanClassification({
   );
 }
 
+function EmptyListMessage({ noCategoriesText }) {
+  return (
+    <ListItem key={noCategoriesText}>
+      <Typography fontSize="small" sx={{ textAlign: "center" }}>
+        {noCategoriesText}
+      </Typography>
+    </ListItem>
+  );
+}
+
 export function CategoriesListToggle({
   categories,
   primaryRgb,
@@ -322,8 +332,11 @@ export function CategoriesListToggle({
   keyword,
   importantSentenceThreshold,
   handleSliderChange,
-  credibilitySignal,
 }) {
+  if (_.isEmpty(categories)) {
+    return <EmptyListMessage noCategoriesText={noCategoriesText} />;
+  }
+
   // categories
   let categoriesList = [];
   let index = 0;
@@ -406,6 +419,8 @@ export function CategoriesListToggle({
     index++;
   }
 
+  importantSentenceThreshold == 99 ? (categoriesList = []) : null;
+
   return (
     <>
       <Typography fontSize="small" sx={{ textAlign: "start" }}>
@@ -421,11 +436,7 @@ export function CategoriesListToggle({
       </Typography>
       <List>
         {_.isEmpty(categoriesList) ? (
-          <ListItem key={noCategoriesText}>
-            <Typography fontSize="small" sx={{ textAlign: "center" }}>
-              {noCategoriesText}
-            </Typography>
-          </ListItem>
+          <EmptyListMessage noCategoriesText={noCategoriesText} />
         ) : (
           categoriesList
         )}


### PR DESCRIPTION
Threshold slider was appearing when there were no techniques detected by classifier. Changed this to a clearer `<EmptyListMessage/>` component for two situations:
- when there are no categories returned by the classifier
- https://www.instagram.com/p/DW3pO0ckgro/
<img width="1136" height="374" alt="Screenshot 2026-06-03 140200" src="https://github.com/user-attachments/assets/b9524cf6-18cf-4af3-a5f3-a508917289e8" />

- when there are results returned by the classifier but no results above a specific `importantSentenceThreshold` - user still needs to use slider to see the other results at lower thresholds (*screenshot shows highlighted sentences because I manually set the empty `categoriesList` to test) 
- https://www.breitbart.com/politics/2025/01/24/exclusive-cia-director-ratcliffe-day-one-thing-chinese-origins-covid-wuhan-lab-leak/
<img width="1132" height="454" alt="Screenshot 2026-06-03 135610" src="https://github.com/user-attachments/assets/e2818233-0cc5-4579-96da-c9964889978e" />

- also removed unused `credibilitySignal`