### PR TITLE
Assistant/prev fact checks fix language

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResult.jsx
@@ -22,6 +22,7 @@ const PreviousFactCheckResult = ({ results }) => {
   const prevFactChecksDone = useSelector(
     (state) => state.assistant.prevFactChecksDone,
   );
+  const locale = useSelector((state) => state.language);
 
   // date information
   dayjs.extend(LocaleData);
@@ -57,10 +58,7 @@ const PreviousFactCheckResult = ({ results }) => {
                   null
                 }
                 website={resultItem.website ?? resultItem.source_name}
-                language={getLanguageName(
-                  resultItem.source_language,
-                  resultItem.source_language,
-                )}
+                language={getLanguageName(resultItem.source_language, locale)}
                 similarityScore={resultItem.score}
                 articleUrl={resultItem.url}
                 domainUrl={resultItem.source_name}

--- a/src/components/NavItems/tools/SemanticSearch/SemanticSearchResults.jsx
+++ b/src/components/NavItems/tools/SemanticSearch/SemanticSearchResults.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useSelector } from "react-redux";
 
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
@@ -17,6 +18,7 @@ import SelectSmall from "./components/SelectSmall";
 
 const SemanticSearchResults = (searchResults) => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/SemanticSearch");
+  const locale = useSelector((state) => state.language);
 
   const sortingModes = [
     {
@@ -132,10 +134,7 @@ const SemanticSearchResults = (searchResults) => {
                     ) ?? null
                   }
                   website={resultItem.website}
-                  language={getLanguageName(
-                    resultItem.language,
-                    resultItem.language,
-                  )}
+                  language={getLanguageName(resultItem.language, locale)}
                   similarityScore={resultItem.similarityScore}
                   articleUrl={resultItem.articleUrl}
                   domainUrl={resultItem.domainUrl}


### PR DESCRIPTION
Closes #1169 

Correctly assign locale language instead of source language of text in Previous fact-check results and Semantic search results
- removes console error from having "pt-pt"
- https://www.snopes.com/fact-check/mccartney-collins-hospital-visit/
<img width="1131" height="1083" alt="Screenshot 2026-06-03 145407" src="https://github.com/user-attachments/assets/09f75cf1-7f36-44e8-ae05-9051bac79a74" />


- Results for Semantic Search tool on text "We will update this article if we receive a response."
<img width="1723" height="713" alt="Screenshot 2026-06-03 150813" src="https://github.com/user-attachments/assets/3fd09c7f-901f-4051-887e-065cd784d9c9" />
