### PR TITLE
Assistant/remove blob URL from display

### DIFF
--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -193,7 +193,6 @@ const Assistant = () => {
             const videoUrl = URL.createObjectURL(fileInput);
             const ctype = TOOLS_CATEGORIES.VIDEO;
 
-            dispatch(setInputUrl(videoUrl, KNOWN_LINKS.OWN));
             dispatch(
               setScrapedData(null, null, null, [], [videoUrl], null, null),
             );
@@ -208,7 +207,6 @@ const Assistant = () => {
             const imageUrl = URL.createObjectURL(fileInput);
             const ctype = TOOLS_CATEGORIES.IMAGE;
 
-            dispatch(setInputUrl(imageUrl, KNOWN_LINKS.OWN)); // kicks off getUrlDomainAnalysisSaga
             dispatch(
               setScrapedData(null, null, null, [imageUrl], [], null, null),
             );


### PR DESCRIPTION
The blob URL was displaying in the input URL box after submitting an uploaded image or video file. This PR stops the URL from displaying.

<img width="1208" height="272" alt="image" src="https://github.com/user-attachments/assets/b56e98de-055d-4d6b-902e-7f31a86e4b69" />
