### PR TITLE
Assistant/Update Youtube Shorts

### DIFF
--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -676,7 +676,7 @@ function* handleMultilingualStanceCall(action) {
     if (
       (urlType === KNOWN_LINKS.YOUTUBE ||
         urlType === KNOWN_LINKS.YOUTUBESHORTS) &&
-      collectedComments.length > 0
+      collectedComments?.length > 0
     ) {
       yield put(setMultilingualStanceDetails(null, true, false, false));
 


### PR DESCRIPTION
The multilingual stance classifier runs (and fails) with youtube shorts when a video has no comments. Added optional chaining to `collectedComments` as it was coming through as null instead of an empty array to check the length
- URL: https://www.youtube.com/shorts/bF0ZLtMx-8w