### PR TITLE
Assistant/persuasion sort categories correctly

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -362,15 +362,16 @@ export function CategoriesListToggle({
     onCategoryChange(currentCategory);
   }
 
-  // order categories by highest count in original classification first, then by categories count as tiebreaker
+  const uniqueScoreCount = (spans) => new Set(spans.map((s) => s.score)).size;
+
+  // order categories by highest chip count first (unique scores), with classification count as tiebreaker
   const sortedCategories = Object.fromEntries(
     Object.entries(categories).sort(([keyA, valA], [keyB, valB]) => {
-      const classificationDiff =
-        (classification[keyB]?.length ?? 0) -
-        (classification[keyA]?.length ?? 0);
-      return classificationDiff !== 0
-        ? classificationDiff
-        : valB.length - valA.length;
+      const chipDiff = uniqueScoreCount(valB) - uniqueScoreCount(valA);
+      return chipDiff !== 0
+        ? chipDiff
+        : (classification[keyB]?.length ?? 0) -
+            (classification[keyA]?.length ?? 0);
     }),
   );
   for (const category in sortedCategories) {

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -295,6 +295,7 @@ export default function AssistantTextSpanClassification({
           <CardContent>
             <CategoriesListToggle
               categories={uniqueCategories}
+              classification={classification}
               primaryRgb={primaryRgb}
               noCategoriesText={keyword("no_detected_techniques")}
               allCategoriesLabel={allCategoriesLabel}
@@ -324,6 +325,7 @@ function EmptyListMessage({ noCategoriesText }) {
 
 export function CategoriesListToggle({
   categories,
+  classification = {},
   primaryRgb,
   noCategoriesText,
   allCategoriesLabel,
@@ -360,9 +362,16 @@ export function CategoriesListToggle({
     onCategoryChange(currentCategory);
   }
 
-  // order categories by highest number of sentences first
+  // order categories by highest count in original classification first, then by categories count as tiebreaker
   const sortedCategories = Object.fromEntries(
-    Object.entries(categories).sort(([, a], [, b]) => b.length - a.length),
+    Object.entries(categories).sort(([keyA, valA], [keyB, valB]) => {
+      const classificationDiff =
+        (classification[keyB]?.length ?? 0) -
+        (classification[keyA]?.length ?? 0);
+      return classificationDiff !== 0
+        ? classificationDiff
+        : valB.length - valA.length;
+    }),
   );
   for (const category in sortedCategories) {
     // don't display overall category


### PR DESCRIPTION
Occasionally is a mismatch between counts of persuasion techniques in `categories` (spans to highlight) and orginal `classification` (classifier result). Then `sortedCategories` would be incorrect as it's based of `categories`. Changed it to check `classification instead`

Incorrect display:
<img width="1175" height="709" alt="image" src="https://github.com/user-attachments/assets/6606da9a-7c61-4591-aa9f-580ca5983618" />


Correct display:
<img width="962" height="743" alt="image" src="https://github.com/user-attachments/assets/2e39e189-b756-4a2c-bd79-26a6b37490be" />




