### PR TITLE
Assistant/Fix treeMapToElementRecursive error

### DIFF
--- a/src/components/NavItems/Assistant/utils/textAnalysisUtils.jsx
+++ b/src/components/NavItems/Assistant/utils/textAnalysisUtils.jsx
@@ -78,7 +78,7 @@ function treeMapToElementsRecursive(
     }
   }
 
-  for (let i = 0; i < treeElem.children.length; i++) {
+  for (let i = 0; i < (treeElem.children?.length ?? 0); i++) {
     childElems.push(
       treeMapToElementsRecursive(
         text,


### PR DESCRIPTION
The plugin was crashing when extracted text sent through from backend contains raw html, it should only send plain text. This was a bug with Mastodon toots which has now been fixed: https://github.com/GateNLP/we-verify-app-assistant/pull/412
- Adding this optional chaining to prevent the plugin from crashing in future for a different reason