### PR TITLE
Assistant/fix settings remount

### DIFF
--- a/src/i18n.jsx
+++ b/src/i18n.jsx
@@ -20,9 +20,9 @@ i18next
     interpolation: {
       escapeValue: false,
     },
-    // react: {
-    //   useSuspense: false,
-    // },
+    react: {
+      useSuspense: false,
+    },
     load: "languageOnly",
     backend: {
       backends: [


### PR DESCRIPTION
Closes #1148 

When the settings is opened for the first time (anywhere in the plugin, not just the Assistant) the whole plugin remounts. 

Uncommenting `useSuspense: false` stops `useTranslation` throwing a Promise for unloaded namespaces, which was causing the app to remount.

I'm not sure why it was uncommented, it doesn't seem to break anything else that I've tested anyway so I hope this is the best fix.
