### PR TITLE
Assistant/fix instagram tests

### DIFF
--- a/tests/e2e/assistant.spec.js
+++ b/tests/e2e/assistant.spec.js
@@ -113,8 +113,9 @@ const MediaServices = {
   // Instagram post with a video reel
   {
     url: "https://www.instagram.com/p/C8JwcyOiFDD/",
+    videoGridIndex: 0,
     mediaType: MediaType.video,
-    mediaStatus: MediaVideoStatus.noEmbed,
+    mediaStatus: MediaVideoStatus.video,
     services: [MediaServices.videoDownloadGeneric],
   },
   // TikTok video post

--- a/tests/unit/assistant.filterResults.spec.js
+++ b/tests/unit/assistant.filterResults.spec.js
@@ -53,8 +53,7 @@ test("tiktok: scraped videos placed in videoList", () => {
 // Instagram
 // ---------------------------------------------------------------------------
 
-// will be unskipped in PR #1203
-test.skip.each([
+test.each([
   {
     label: "video and images",
     videos: ["https://cdn.ig.com/v.mp4"],


### PR DESCRIPTION
Unskipped Instagram unit tests

Fixed Instagram e2e tests since backend (https://github.com/GateNLP/we-verify-app-assistant/pull/405) and frontend (#1203) changes
- the test link has images and videos, specify first video to select
- video status was set to `noEmbed`, change this to `video`
