### PR TITLE
Assistant/domain cred add spacing

### DIFF
--- a/src/components/NavItems/Assistant/components/DomainDialog.jsx
+++ b/src/components/NavItems/Assistant/components/DomainDialog.jsx
@@ -75,7 +75,7 @@ export function DomainDialog({
                   color={trafficLightColor}
                   size="small"
                 />
-                {keyword("url_domain_analysis_popup_header_domain")}
+                {keyword("url_domain_analysis_popup_header_domain")}{" "}
                 {value.source}
               </Typography>
             </Grid>


### PR DESCRIPTION
This PR adds a missing space between the header and the source type
<img width="1346" height="114" alt="image" src="https://github.com/user-attachments/assets/8aef25f2-a731-4e33-83be-34834b55d63e" />
